### PR TITLE
feat: modernize portfolio layout and motion system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portfolio",
-  "version": "1.15.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portfolio",
-      "version": "1.15.0",
+      "version": "1.17.0",
       "dependencies": {
         "@radix-ui/react-navigation-menu": "^1.2.3",
         "@radix-ui/react-select": "^2.1.4",
@@ -19,6 +19,7 @@
         "clsx": "^2.1.1",
         "contentful": "^11.4.1",
         "dompurify": "^3.2.3",
+        "framer-motion": "^12.38.0",
         "lucide-react": "^0.469.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -70,7 +71,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1180,7 +1180,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1196,14 +1195,12 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1220,7 +1217,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1245,7 +1241,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1259,7 +1254,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1268,7 +1262,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1276,14 +1269,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1293,7 +1284,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -1306,7 +1296,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -1315,7 +1304,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1473,7 +1461,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -3016,13 +3003,13 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3032,7 +3019,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3567,7 +3554,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3592,14 +3578,12 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3608,11 +3592,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3723,8 +3718,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
@@ -3736,7 +3730,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -3764,7 +3757,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -3853,7 +3845,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -3931,7 +3922,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -3955,7 +3945,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4144,7 +4133,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -4379,7 +4367,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4426,7 +4413,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -4451,7 +4437,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4538,8 +4524,7 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4556,8 +4541,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.6.3",
@@ -4610,8 +4594,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.76",
@@ -4622,8 +4605,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/emojilib": {
       "version": "2.4.0",
@@ -5165,7 +5147,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5181,7 +5162,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -5205,7 +5185,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
       "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -5261,7 +5240,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5360,7 +5338,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -5376,7 +5353,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -5410,6 +5386,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -5438,7 +5441,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5560,7 +5562,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -5580,7 +5581,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -5592,7 +5592,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5601,7 +5600,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -5960,7 +5958,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -5972,7 +5969,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -5987,7 +5983,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5996,7 +5991,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6005,7 +5999,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -6017,7 +6010,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6082,8 +6074,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/issue-parser": {
       "version": "7.0.1",
@@ -6159,7 +6150,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -6183,7 +6173,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6362,7 +6351,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -6373,8 +6361,7 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -6627,7 +6614,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6636,13 +6622,24 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -6731,10 +6728,24 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -6755,7 +6766,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -6766,7 +6776,6 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6837,7 +6846,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9638,7 +9646,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9647,7 +9654,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -9805,8 +9811,7 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9883,7 +9888,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9891,14 +9895,12 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9913,8 +9915,7 @@
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9946,12 +9947,13 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -9970,7 +9972,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10050,7 +10051,6 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10078,7 +10078,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -10095,7 +10094,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -10114,7 +10112,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10149,7 +10146,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10174,7 +10170,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10186,8 +10181,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10297,7 +10291,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10469,7 +10462,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -10478,7 +10470,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10538,12 +10529,23 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -10619,7 +10621,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -10648,7 +10649,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -10702,7 +10702,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11093,7 +11092,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -11105,7 +11103,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11338,7 +11335,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11425,7 +11421,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11440,7 +11435,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11454,7 +11448,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11467,7 +11460,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -11479,7 +11471,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11488,7 +11479,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -11539,7 +11529,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -11604,7 +11593,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11631,7 +11619,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11768,7 +11755,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "dependencies": {
         "any-promise": "^1.0.0"
       }
@@ -11777,7 +11763,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -11835,18 +11820,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinypool": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -11896,7 +11869,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -11964,8 +11936,7 @@
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -12203,8 +12174,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12437,7 +12407,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -12483,7 +12452,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -12501,7 +12469,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12518,7 +12485,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -12529,14 +12495,12 @@
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -12553,7 +12517,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -12628,7 +12591,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "contentful": "^11.4.1",
     "dompurify": "^3.2.3",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^0.469.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/AppBullet.tsx
+++ b/src/components/AppBullet.tsx
@@ -1,20 +1,24 @@
 import DOMPurify from "dompurify";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, LucideIcon } from "lucide-react";
 
 interface AppBulletProps {
   bulletText: string;
+  icon?: LucideIcon;
 }
 
-export default function AppBullet({ bulletText }: AppBulletProps) {
+export default function AppBullet({
+  bulletText,
+  icon: Icon = ChevronRight,
+}: AppBulletProps) {
   const sanitize = (text: string) => DOMPurify.sanitize(text);
   return (
     <div className="flex items-start gap-4">
-      <div>
-        <ChevronRight size={18} className="text-fontColor mt-1" />
+      <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-surface-1 border border-border shrink-0 mt-0.5">
+        <Icon size={16} className="text-fontColor" />
       </div>
       <p
         dangerouslySetInnerHTML={{ __html: sanitize(bulletText) }}
-        className="text-sm md:text-lg font-light text-muted-foreground [&>strong]:text-foreground"
+        className="text-sm md:text-lg font-light text-muted-foreground [&>strong]:text-foreground pt-1"
       ></p>
     </div>
   );

--- a/src/components/AppCard.tsx
+++ b/src/components/AppCard.tsx
@@ -1,55 +1,109 @@
 import { ICard } from "@/interfaces/card.interface";
-import { Check } from "lucide-react";
+import { motion } from "framer-motion";
+import { ArrowUpRight } from "lucide-react";
 import { Badge } from "./ui/badge";
+
+type CardVariant = "default" | "featured";
 
 interface AppCardProps {
   card: ICard;
+  variant?: CardVariant;
+  className?: string;
 }
 
-export default function AppCard({ card }: AppCardProps) {
+export default function AppCard({
+  card,
+  variant = "default",
+  className = "",
+}: AppCardProps) {
+  const isFeatured = variant === "featured";
+
   return (
-    <div className="flex flex-col justify-between border border-border min-h-[210px] max-h-[420px] w-full rounded-lg shadow-lg p-4 transition-transform hover:scale-105">
-      {/* Card Title */}
-      <div>
-        <h2 className="text-lg md:text-xl font-semibold text-foreground mb-1">
-          <a
-            href={card.cardTitleLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="no-underline hover:text-fontColor after-line"
+    <motion.div
+      whileHover={{ y: -4 }}
+      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+      className={`group relative h-full ${className}`}
+    >
+      <div
+        aria-hidden
+        className="absolute -inset-px rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-accent-from to-accent-to blur-[1px]"
+      />
+      <div
+        className={`relative flex flex-col justify-between h-full rounded-2xl bg-surface-1 border border-border p-5 md:p-6 overflow-hidden ${
+          isFeatured ? "min-h-[320px]" : "min-h-[240px]"
+        }`}
+      >
+        {card.image && (
+          <div
+            className={`-mx-5 -mt-5 md:-mx-6 md:-mt-6 mb-5 overflow-hidden border-b border-border bg-surface-2 ${
+              isFeatured ? "h-48 md:h-64" : "h-32"
+            }`}
           >
-            {card.cardTitle}
-          </a>
-        </h2>
+            <img
+              src={card.image}
+              alt={card.cardTitle}
+              loading="lazy"
+              className="w-full h-full object-cover transition-transform duration-700 ease-snappy group-hover:scale-105"
+            />
+          </div>
+        )}
 
-        {/* Card Subtitle */}
-        <p className="text-sm text-muted-foreground mb-4">
-          {card.cardSubtitle}
-        </p>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <h3
+              className={`font-semibold text-foreground leading-tight ${
+                isFeatured ? "text-2xl md:text-3xl" : "text-lg md:text-xl"
+              }`}
+            >
+              <a
+                href={card.cardTitleLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="no-underline inline-flex items-center gap-1.5 hover:text-fontColor transition-colors"
+              >
+                {card.cardTitle}
+                <ArrowUpRight
+                  size={isFeatured ? 22 : 18}
+                  className="text-muted-foreground group-hover:text-fontColor transition-colors"
+                />
+              </a>
+            </h3>
+          </div>
 
-        {/* Highlights List */}
-        <ul className="space-y-2">
-          {card.highlights.map((highlight) => (
-            <li key={highlight} className="flex text-sm text-foreground">
-              <span>
-                <Check className="text-fontColor mr-2 mt-1" size={12} />
-              </span>
-              {highlight}
-            </li>
-          ))}
-        </ul>
-      </div>
+          <p
+            className={`text-muted-foreground ${
+              isFeatured ? "text-base" : "text-sm"
+            }`}
+          >
+            {card.cardSubtitle}
+          </p>
 
-      <div>
-        {/* Technologies */}
-        <div className="flex flex-wrap gap-2 mt-6">
+          <ul className="space-y-1.5 mt-1">
+            {card.highlights.map((highlight, i) => (
+              <li
+                key={highlight}
+                className="flex gap-2.5 text-sm text-foreground/90"
+              >
+                <span
+                  aria-hidden
+                  className="font-display text-fontColor leading-none mt-1 select-none"
+                >
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span>{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5 mt-5 pt-4 border-t border-border/60">
           {card.technologies.map((technology) => (
-            <Badge variant={"outline"} key={technology}>
+            <Badge variant="outline" key={technology} className="font-normal">
               {technology}
             </Badge>
           ))}
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/AppNavigationMenu.tsx
+++ b/src/components/AppNavigationMenu.tsx
@@ -1,4 +1,7 @@
+import { useActiveSection } from "@/hooks/useActiveSection";
 import { RootState } from "@/store/store";
+import { motion } from "framer-motion";
+import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import AppLanguageSelector from "./AppLanguageSelector";
 import AppResumeButton from "./AppResumeButton";
@@ -9,24 +12,46 @@ export function AppNavigationMenu() {
     (state: RootState) => state.contentV2.data.navbar.menu
   );
 
+  const ids = useMemo(() => menuItems.map((m) => m.id), [menuItems]);
+  const active = useActiveSection(ids);
+
   return (
     <>
-      <nav className="hidden md:flex fixed top-0 left-0 z-10 w-full bg-background/80 backdrop-blur-md">
-        <ul className="flex justify-end items-center space-x-6 p-6 text-sm text-neutral-1">
-          {menuItems.map((item) => (
-            <li key={item.id} className="flex items-center">
-              <a
-                href={`#${item.id}`}
-                className="ml-2 hover:text-primaryColor no-underline relative after-line"
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
+      <nav className="hidden md:flex fixed top-4 left-1/2 -translate-x-1/2 z-30">
+        <ul className="flex items-center gap-1 p-1.5 rounded-full border border-border bg-background/70 backdrop-blur-xl shadow-lg shadow-black/5">
+          {menuItems.map((item) => {
+            const isActive = active === item.id;
+            return (
+              <li key={item.id} className="relative">
+                <a
+                  href={`#${item.id}`}
+                  className={`relative z-10 inline-flex items-center px-3.5 py-1.5 text-sm rounded-full transition-colors ${
+                    isActive
+                      ? "text-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {item.label}
+                </a>
+                {isActive && (
+                  <motion.span
+                    layoutId="nav-active-pill"
+                    aria-hidden
+                    className="absolute inset-0 rounded-full bg-surface-2 border border-border"
+                    transition={{
+                      type: "spring",
+                      stiffness: 380,
+                      damping: 30,
+                    }}
+                  />
+                )}
+              </li>
+            );
+          })}
         </ul>
       </nav>
 
-      <div className="flex items-start justify-end w-full md:w-auto gap-4 fixed top-0 right-0 z-20 p-4 md:p-4 rounded-lg bg-background/80 backdrop-blur-md md:bg-transparent md:backdrop-blur-0">
+      <div className="flex items-center justify-end w-full md:w-auto gap-2 fixed top-0 right-0 z-20 p-4 md:top-4 md:right-4 md:p-2 md:rounded-full md:border md:border-border md:bg-background/70 md:backdrop-blur-xl md:shadow-lg md:shadow-black/5 bg-background/80 backdrop-blur-md md:bg-background/70">
         <AppLanguageSelector />
         <AppResumeButton />
         <ThemeToggle />

--- a/src/components/AppSectionWrapper.tsx
+++ b/src/components/AppSectionWrapper.tsx
@@ -6,6 +6,7 @@ interface AppSectionWrapperProps {
   sectionTitle?: string;
   sectionId: string;
   nextSectionId?: string;
+  hideHeader?: boolean;
 }
 
 export default function AppSectionWrapper({
@@ -14,27 +15,32 @@ export default function AppSectionWrapper({
   sectionTitle,
   sectionId,
   nextSectionId,
+  hideHeader = false,
 }: AppSectionWrapperProps) {
   return (
     <section
       id={sectionId}
-      className="min-h-screen flex flex-col justify-between px-6 pt-24 pb-6 mx-auto w-full max-w-6xl transition-colors duration-300"
+      className="relative min-h-screen flex flex-col justify-between px-6 pt-24 pb-10 mx-auto w-full max-w-6xl transition-colors duration-300"
     >
-      {/* Section Header */}
-      <div className="mb-6">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold">
-          <span className="text-lg sm:text-xl lg:text-2xl text-fontColor font-light">
-            {sectionNumber ? `${sectionNumber}. ` : ""}
-          </span>
-          {sectionTitle}
-        </h2>
-      </div>
+      {!hideHeader && (sectionNumber || sectionTitle) && (
+        <div className="mb-10 flex items-end gap-4 md:gap-6">
+          {sectionNumber && (
+            <span className="font-display text-5xl md:text-7xl leading-none text-gradient select-none">
+              {sectionNumber}
+            </span>
+          )}
+          <div className="flex flex-1 items-end gap-4 pb-1 md:pb-2">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold tracking-tight">
+              {sectionTitle}
+            </h2>
+            <span className="hidden sm:block flex-1 h-px bg-border mb-2" />
+          </div>
+        </div>
+      )}
 
-      {/* Section Content */}
-      <div className="max-w-6xl">{children}</div>
+      <div className="flex-1 flex flex-col justify-center">{children}</div>
 
-      {/* Next Section Button */}
-      <div className="mt-6 flex justify-center">
+      <div className="mt-10 flex justify-center">
         <AppNextSectionButton sectionId={nextSectionId} />
       </div>
     </section>

--- a/src/components/motion/FadeIn.tsx
+++ b/src/components/motion/FadeIn.tsx
@@ -1,0 +1,31 @@
+import { HTMLMotionProps, motion } from "framer-motion";
+
+interface FadeInProps extends HTMLMotionProps<"div"> {
+  delay?: number;
+  y?: number;
+  duration?: number;
+}
+
+export default function FadeIn({
+  children,
+  delay = 0,
+  y = 24,
+  duration = 0.6,
+  ...props
+}: FadeInProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-80px" }}
+      transition={{
+        duration,
+        delay,
+        ease: [0.22, 1, 0.36, 1],
+      }}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/motion/Spotlight.tsx
+++ b/src/components/motion/Spotlight.tsx
@@ -1,0 +1,42 @@
+import { motion, useMotionTemplate, useMotionValue } from "framer-motion";
+import { useEffect, useRef } from "react";
+
+interface SpotlightProps {
+  className?: string;
+  size?: number;
+  opacity?: number;
+}
+
+export default function Spotlight({
+  className = "",
+  size = 520,
+  opacity = 0.18,
+}: SpotlightProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const mouseX = useMotionValue(-9999);
+  const mouseY = useMotionValue(-9999);
+
+  useEffect(() => {
+    const handleMove = (e: MouseEvent) => {
+      const rect = ref.current?.getBoundingClientRect();
+      if (!rect) return;
+      mouseX.set(e.clientX - rect.left);
+      mouseY.set(e.clientY - rect.top);
+    };
+
+    window.addEventListener("mousemove", handleMove);
+    return () => window.removeEventListener("mousemove", handleMove);
+  }, [mouseX, mouseY]);
+
+  const background = useMotionTemplate`radial-gradient(${size}px circle at ${mouseX}px ${mouseY}px, hsl(var(--accent-from) / ${opacity}), transparent 70%)`;
+
+  return (
+    <div
+      ref={ref}
+      className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}
+      aria-hidden="true"
+    >
+      <motion.div className="absolute inset-0" style={{ background }} />
+    </div>
+  );
+}

--- a/src/components/motion/Stagger.tsx
+++ b/src/components/motion/Stagger.tsx
@@ -1,0 +1,55 @@
+import { HTMLMotionProps, motion, Variants } from "framer-motion";
+
+interface StaggerProps extends HTMLMotionProps<"div"> {
+  staggerDelay?: number;
+  initialDelay?: number;
+}
+
+const containerVariants = (
+  staggerDelay: number,
+  initialDelay: number
+): Variants => ({
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: staggerDelay,
+      delayChildren: initialDelay,
+    },
+  },
+});
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+export function Stagger({
+  children,
+  staggerDelay = 0.08,
+  initialDelay = 0,
+  ...props
+}: StaggerProps) {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-80px" }}
+      variants={containerVariants(staggerDelay, initialDelay)}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function StaggerItem({ children, ...props }: HTMLMotionProps<"div">) {
+  return (
+    <motion.div variants={itemVariants} {...props}>
+      {children}
+    </motion.div>
+  );
+}

--- a/src/consts/en.const.ts
+++ b/src/consts/en.const.ts
@@ -34,6 +34,17 @@ export const ENGLISH: PortfolioContent = {
     name: "Leonardo Grigorio Ferreira",
     description:
       "I’m a Software Engineer specialized in Web Development and Cloud Technologies",
+    role: "Software Engineer",
+    status: "Available for new opportunities",
+    stats: [
+      { value: "4+", label: "Years coding" },
+      { value: "AWS", label: "Certified" },
+      { value: "Itaú", label: "Currently at" },
+    ],
+    cta: {
+      primary: "Get in touch",
+      secondary: "View work",
+    },
   },
   about: {
     title: "About Me",

--- a/src/consts/pt.const.ts
+++ b/src/consts/pt.const.ts
@@ -32,6 +32,17 @@ export const PORTUGUESE = {
     name: "Leonardo Grigorio Ferreira",
     description:
       "Sou um Engenheiro de Software especializado em Desenvolvimento Web e Tecnologias Cloud",
+    role: "Engenheiro de Software",
+    status: "Disponível para novas oportunidades",
+    stats: [
+      { value: "4+", label: "Anos de carreira" },
+      { value: "AWS", label: "Certificado" },
+      { value: "Itaú", label: "Atualmente no" },
+    ],
+    cta: {
+      primary: "Entrar em contato",
+      secondary: "Ver projetos",
+    },
   },
   about: {
     title: "Sobre Mim",

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+export function useActiveSection(sectionIds: string[]): string | null {
+  const [active, setActive] = useState<string | null>(sectionIds[0] ?? null);
+
+  useEffect(() => {
+    if (sectionIds.length === 0) return;
+
+    const visibility = new Map<string, number>();
+    sectionIds.forEach((id) => visibility.set(id, 0));
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          visibility.set(entry.target.id, entry.intersectionRatio);
+        });
+
+        let topId: string | null = null;
+        let topRatio = 0;
+        visibility.forEach((ratio, id) => {
+          if (ratio > topRatio) {
+            topRatio = ratio;
+            topId = id;
+          }
+        });
+
+        if (topId) setActive(topId);
+      },
+      {
+        threshold: [0.15, 0.35, 0.55, 0.75],
+        rootMargin: "-20% 0px -40% 0px",
+      }
+    );
+
+    const elements: Element[] = [];
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) {
+        observer.observe(el);
+        elements.push(el);
+      }
+    });
+
+    return () => {
+      elements.forEach((el) => observer.unobserve(el));
+      observer.disconnect();
+    };
+  }, [sectionIds]);
+
+  return active;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&family=Space+Grotesk:wght@300..700&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -40,6 +40,70 @@
     width: 100%;
     left: 0;
   }
+
+  .text-gradient {
+    background: linear-gradient(
+      135deg,
+      hsl(var(--accent-from)) 0%,
+      hsl(var(--accent-to)) 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+
+  .bg-grid {
+    background-image: linear-gradient(
+        to right,
+        hsl(var(--grid)) 1px,
+        transparent 1px
+      ),
+      linear-gradient(to bottom, hsl(var(--grid)) 1px, transparent 1px);
+    background-size: 48px 48px;
+  }
+
+  .bg-grid-fade {
+    mask-image: radial-gradient(
+      ellipse at center,
+      black 30%,
+      transparent 75%
+    );
+    -webkit-mask-image: radial-gradient(
+      ellipse at center,
+      black 30%,
+      transparent 75%
+    );
+  }
+
+  .bg-noise {
+    background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.35 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  }
+
+  .pulse-dot {
+    position: relative;
+  }
+
+  .pulse-dot::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 9999px;
+    background: currentColor;
+    opacity: 0.5;
+    animation: pulseDot 2s ease-out infinite;
+  }
+
+  @keyframes pulseDot {
+    0% {
+      transform: scale(1);
+      opacity: 0.6;
+    }
+    100% {
+      transform: scale(2.4);
+      opacity: 0;
+    }
+  }
 }
 
 @layer base {
@@ -74,6 +138,15 @@
     --neutral-1: #1e1e1e;
     --neutral-2: #1a1a1ab0;
     --primary-1: #386ec4;
+
+    --accent-from: 244 75% 57%;
+    --accent-to: 217 91% 60%;
+    --surface-1: 210 40% 98%;
+    --surface-2: 210 40% 96%;
+    --grid: 220 13% 91%;
+    --scrollbar-track: 210 40% 96%;
+    --scrollbar-thumb: 215 20% 75%;
+    --scrollbar-thumb-hover: 215 20% 60%;
   }
   .dark {
     --background: 0 0% 0%;
@@ -105,6 +178,15 @@
     --neutral-1: #e3e4e6;
     --neutral-2: #e3e4e680;
     --primary-1: #1486cc;
+
+    --accent-from: 263 85% 70%;
+    --accent-to: 188 95% 60%;
+    --surface-1: 222 30% 7%;
+    --surface-2: 222 25% 10%;
+    --grid: 217 32% 14%;
+    --scrollbar-track: 0 0% 4%;
+    --scrollbar-thumb: 217 32% 18%;
+    --scrollbar-thumb-hover: 217 32% 28%;
   }
 }
 
@@ -119,11 +201,8 @@
 
 html {
   scroll-behavior: smooth;
-}
-
-html {
   scrollbar-width: thin;
-  scrollbar-color: #1e293b #0f172a;
+  scrollbar-color: hsl(var(--scrollbar-thumb)) hsl(var(--scrollbar-track));
 }
 
 html::-webkit-scrollbar {
@@ -131,14 +210,14 @@ html::-webkit-scrollbar {
 }
 
 html::-webkit-scrollbar-track {
-  background: #0f172a;
+  background: hsl(var(--scrollbar-track));
 }
 
 html::-webkit-scrollbar-thumb {
-  background: #1e293b;
+  background: hsl(var(--scrollbar-thumb));
   border-radius: 4px;
 }
 
 html::-webkit-scrollbar-thumb:hover {
-  background: #334155;
+  background: hsl(var(--scrollbar-thumb-hover));
 }

--- a/src/interfaces/card.interface.ts
+++ b/src/interfaces/card.interface.ts
@@ -4,4 +4,5 @@ export interface ICard {
   cardSubtitle: string;
   highlights: string[];
   technologies: string[];
+  image?: string;
 }

--- a/src/interfaces/portfolio-content.interface.ts
+++ b/src/interfaces/portfolio-content.interface.ts
@@ -28,6 +28,18 @@ export interface Language {
 export interface Home {
   name: string;
   description: string;
+  role: string;
+  status: string;
+  stats: HomeStat[];
+  cta: {
+    primary: string;
+    secondary: string;
+  };
+}
+
+export interface HomeStat {
+  value: string;
+  label: string;
 }
 
 export interface BulletList {

--- a/src/sections/About.tsx
+++ b/src/sections/About.tsx
@@ -1,7 +1,19 @@
 import AppBullet from "@/components/AppBullet";
 import AppSectionWrapper from "@/components/AppSectionWrapper";
+import FadeIn from "@/components/motion/FadeIn";
+import { Stagger, StaggerItem } from "@/components/motion/Stagger";
 import { RootState } from "@/store/store";
-import { useSelector } from "react-redux";
+import { Award, Briefcase, Code2, Database, Globe2, LucideIcon, Zap } from "lucide-react";
+import { shallowEqual, useSelector } from "react-redux";
+
+const BULLET_ICONS: LucideIcon[] = [
+  Briefcase,
+  Code2,
+  Globe2,
+  Database,
+  Award,
+  Zap,
+];
 
 export default function About() {
   const aboutData = useSelector((state: RootState) => {
@@ -11,7 +23,7 @@ export default function About() {
       image: state.content.data?.profilePicture.fields.file.url,
       sectionTitle: state.content.data?.others.sections.about,
     };
-  });
+  }, shallowEqual);
 
   return (
     <AppSectionWrapper
@@ -20,37 +32,50 @@ export default function About() {
       sectionTitle={aboutData.sectionTitle ?? "About"}
       sectionNumber="02"
     >
-      <div className="flex flex-col-reverse md:flex-row items-center md:items-start gap-8 md:gap-16 lg:gap-32">
-        {/* Text Section */}
-        <div className="w-full md:w-1/2 space-y-4">
+      <div className="flex flex-col-reverse md:flex-row items-center md:items-start gap-10 md:gap-16 lg:gap-24">
+        <Stagger className="w-full md:flex-1 space-y-5">
           {aboutData.bullets?.map((paragraph: string, index: number) => (
-            <AppBullet bulletText={paragraph} key={`bullet-${index}`} />
+            <StaggerItem key={`bullet-${index}`}>
+              <AppBullet
+                bulletText={paragraph}
+                icon={BULLET_ICONS[index % BULLET_ICONS.length]}
+              />
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
 
-        {/* Image Section */}
-        <div className="relative w-32 sm:w-40 md:w-56 lg:w-64">
-          {/* Profile Image */}
-          <img
-            className="rounded-full w-full h-auto object-cover border border-fontColor shadow-lg"
-            src={aboutData.image}
-            alt="Leonardo Grigorio Ferreira"
-          />
-
-          {/* Badge */}
-          <a
-            href="https://www.credly.com/badges/08549e01-a715-4af4-9188-2f7cb18cf207"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="absolute bottom-0 right-0 transform hover:scale-110 transition-transform duration-300"
-          >
-            <img
-              src="https://miro.medium.com/v2/resize:fit:512/0*P7dmdm5OCZaMEPOG"
-              alt="AWS Certification Badge"
-              className="w-12 sm:w-16 lg:w-20"
+        <FadeIn y={32} className="relative shrink-0">
+          <div className="relative w-44 sm:w-52 md:w-60 lg:w-72 aspect-square">
+            <div
+              aria-hidden
+              className="absolute -inset-6 rounded-full bg-gradient-to-br from-accent-from to-accent-to opacity-30 blur-3xl"
             />
-          </a>
-        </div>
+            <div
+              aria-hidden
+              className="absolute inset-0 rounded-full bg-gradient-to-br from-accent-from to-accent-to p-[2px]"
+            >
+              <div className="w-full h-full rounded-full bg-background" />
+            </div>
+            <img
+              src={aboutData.image}
+              alt="Leonardo Grigorio Ferreira"
+              className="relative w-full h-full object-cover rounded-full shadow-2xl"
+            />
+            <a
+              href="https://www.credly.com/badges/08549e01-a715-4af4-9188-2f7cb18cf207"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute bottom-1 right-1 transform hover:scale-110 transition-transform duration-300"
+              aria-label="AWS Certification"
+            >
+              <img
+                src="https://miro.medium.com/v2/resize:fit:512/0*P7dmdm5OCZaMEPOG"
+                alt="AWS Certification Badge"
+                className="w-14 sm:w-16 lg:w-20 drop-shadow-lg"
+              />
+            </a>
+          </div>
+        </FadeIn>
       </div>
     </AppSectionWrapper>
   );

--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -1,44 +1,79 @@
 import AppSectionWrapper from "@/components/AppSectionWrapper";
+import FadeIn from "@/components/motion/FadeIn";
+import { Stagger, StaggerItem } from "@/components/motion/Stagger";
+import { Button } from "@/components/ui/button";
 import { CONTACTS } from "@/consts/contact.const";
 import { RootState } from "@/store/store";
-import { useSelector } from "react-redux";
+import { ArrowUpRight, Mail } from "lucide-react";
+import { shallowEqual, useSelector } from "react-redux";
+
+const EMAIL = "leo.grigorio16@gmail.com";
 
 export default function Contact() {
-  const contactData = useSelector((state: RootState) => {
-    return {
+  const contactData = useSelector(
+    (state: RootState) => ({
       sectionTitle: state.content.data?.others.sections.contact,
       sectionSubtitle: state.content.data?.others.contact.title,
       sectionParagraph: state.content.data?.others.contact.paragraph,
-    };
-  });
+    }),
+    shallowEqual
+  );
 
   return (
     <AppSectionWrapper
       sectionId="contact"
       sectionNumber="05"
-      sectionTitle={contactData.sectionSubtitle}
+      sectionTitle={contactData.sectionTitle ?? "Contact"}
     >
-      <div className="w-full flex flex-col items-center text-center">
-        <h2 className="text-3xl font-bold mb-6">{contactData.sectionTitle}</h2>
-        <p className="text-lg text-muted-foreground mb-8 max-w-xl">
-          {contactData.sectionParagraph}
-        </p>
-        <div className="flex flex-wrap justify-center gap-8 w-full">
-          {CONTACTS.map((link, index) => (
-            <a
-              key={index}
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex flex-col items-center group text-foreground hover:text-fontColor transform transition-transform hover:scale-110"
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-start">
+        <FadeIn className="lg:col-span-3">
+          <h3 className="font-display text-4xl md:text-5xl lg:text-6xl leading-[1.05] tracking-tight">
+            {contactData.sectionSubtitle ?? "Let's build something."}
+          </h3>
+          <p className="text-base md:text-lg text-muted-foreground mt-6 max-w-xl">
+            {contactData.sectionParagraph}
+          </p>
+
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Button
+              asChild
+              size="lg"
+              className="rounded-full group h-12 pl-5 pr-4"
             >
-              <div className="p-4 flex items-center justify-center">
-                {link.icon}
-              </div>
-              <span className="text-sm mt-2">{link.label}</span>
-            </a>
+              <a href={`mailto:${EMAIL}`}>
+                <Mail className="mr-1" />
+                {EMAIL}
+                <ArrowUpRight className="ml-1 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+              </a>
+            </Button>
+          </div>
+        </FadeIn>
+
+        <Stagger className="lg:col-span-2 grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-1 gap-3 w-full">
+          {CONTACTS.map((link) => (
+            <StaggerItem key={link.label}>
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group relative flex items-center gap-4 p-4 rounded-xl border border-border bg-surface-1 hover:bg-surface-2 transition-colors"
+              >
+                <div className="flex items-center justify-center w-11 h-11 rounded-lg bg-background border border-border text-foreground group-hover:text-fontColor transition-colors shrink-0 [&_svg]:size-5">
+                  {link.icon}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-foreground">
+                    {link.label}
+                  </p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {link.href.replace(/^(https?:\/\/|mailto:)/, "")}
+                  </p>
+                </div>
+                <ArrowUpRight className="size-4 text-muted-foreground group-hover:text-fontColor transition-colors shrink-0" />
+              </a>
+            </StaggerItem>
           ))}
-        </div>
+        </Stagger>
       </div>
     </AppSectionWrapper>
   );

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,56 +1,76 @@
 import AppCard from "@/components/AppCard";
 import AppSectionWrapper from "@/components/AppSectionWrapper";
+import FadeIn from "@/components/motion/FadeIn";
+import { Badge } from "@/components/ui/badge";
 import { RootState } from "@/store/store";
-import { useSelector } from "react-redux";
+import { shallowEqual, useSelector } from "react-redux";
 
 export default function Experience() {
-  const experienceData = useSelector((state: RootState) => {
-    const _data = state.content.data?.experience[0];
-    return {
-      company: _data?.company,
-      role: _data?.role,
-      period: _data?.period,
-      description: _data?.description,
-      experiences: _data?.projects,
+  const { experiences, sectionTitle } = useSelector(
+    (state: RootState) => ({
+      experiences: state.content.data?.experience ?? [],
       sectionTitle: state.content.data?.others.sections.experience,
-    };
-  });
+    }),
+    shallowEqual
+  );
 
   return (
     <AppSectionWrapper
       sectionId="experience"
-      sectionTitle={experienceData.sectionTitle ?? "Experience"}
+      sectionTitle={sectionTitle ?? "Experience"}
       sectionNumber="03"
       nextSectionId="projects"
     >
-      <div className="flex flex-col">
-        <div className="w-full max-w-6xl">
-          {/* Experience Header */}
-          <div className="mb-8">
-            <h3 className="text-xl font-semibold">
-              {`${experienceData.role} `}
-              <a
-                href="https://www.nttdata.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-fontColor no-underline after-line"
-              >
-                @ {experienceData.company}
-              </a>
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              {experienceData.period}
-            </p>
-            <p className="text-sm md:text-base mt-4">
-              {experienceData.description}
-            </p>
-          </div>
-        </div>
+      <div className="relative md:pl-8">
+        <span
+          aria-hidden
+          className="hidden md:block absolute left-2 top-3 bottom-3 w-px bg-gradient-to-b from-accent-from/60 via-border to-transparent"
+        />
 
-        {/* Projects */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {experienceData.experiences?.map((project) => (
-            <AppCard card={project} key={project.cardTitle} />
+        <div className="flex flex-col gap-16 md:gap-20">
+          {experiences.map((experience, idx) => (
+            <FadeIn
+              key={`${experience.company}-${idx}`}
+              delay={idx * 0.05}
+              className="relative"
+            >
+              <span
+                aria-hidden
+                className="hidden md:block absolute -left-8 top-2 w-4 h-4 rounded-full bg-gradient-to-br from-accent-from to-accent-to ring-4 ring-background"
+              />
+
+              <div className="mb-6">
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <h3 className="text-xl md:text-2xl font-semibold tracking-tight">
+                    {experience.role}
+                  </h3>
+                  <span className="text-muted-foreground">@</span>
+                  <a
+                    href="#"
+                    onClick={(e) => e.preventDefault()}
+                    className="text-fontColor no-underline after-line text-lg md:text-xl"
+                  >
+                    {experience.company}
+                  </a>
+                </div>
+                <Badge variant="outline" className="mt-3 font-normal">
+                  {experience.period}
+                </Badge>
+                {experience.description && (
+                  <p className="text-sm md:text-base text-muted-foreground mt-4 max-w-3xl">
+                    {experience.description}
+                  </p>
+                )}
+              </div>
+
+              {experience.projects && experience.projects.length > 0 && (
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+                  {experience.projects.map((project) => (
+                    <AppCard card={project} key={project.cardTitle} />
+                  ))}
+                </div>
+              )}
+            </FadeIn>
           ))}
         </div>
       </div>

--- a/src/sections/Projects.tsx
+++ b/src/sections/Projects.tsx
@@ -1,16 +1,21 @@
 import AppCard from "@/components/AppCard";
 import AppSectionWrapper from "@/components/AppSectionWrapper";
+import FadeIn from "@/components/motion/FadeIn";
+import { Stagger, StaggerItem } from "@/components/motion/Stagger";
 import { RootState } from "@/store/store";
-import { useSelector } from "react-redux";
+import { shallowEqual, useSelector } from "react-redux";
 
 export default function Projects() {
-  const projectsData = useSelector((state: RootState) => {
-    return {
+  const projectsData = useSelector(
+    (state: RootState) => ({
       paragraph: state.content.data?.projects.paragraph,
-      projects: state.content.data?.projects.projects,
-      sectionTitle: state.content.data?.others.sections.about,
-    };
-  });
+      projects: state.content.data?.projects.projects ?? [],
+      sectionTitle: state.content.data?.others.sections.projects,
+    }),
+    shallowEqual
+  );
+
+  const projects = projectsData.projects;
 
   return (
     <AppSectionWrapper
@@ -19,16 +24,33 @@ export default function Projects() {
       sectionId="projects"
       nextSectionId="contact"
     >
-      <h3 className="text-lg md:text-xl font-semibold mb-8">
-        {projectsData.paragraph}
-      </h3>
+      {projectsData.paragraph && (
+        <FadeIn>
+          <p className="text-base md:text-lg font-light text-muted-foreground max-w-3xl mb-10">
+            {projectsData.paragraph}
+          </p>
+        </FadeIn>
+      )}
 
-      {/* Projects Grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {projectsData.projects?.map((project, index) => (
-          <AppCard card={project} key={`project-${index}`} />
-        ))}
-      </div>
+      <Stagger
+        staggerDelay={0.08}
+        className="grid grid-cols-1 md:grid-cols-2 gap-5"
+      >
+        {projects.map((project, index) => {
+          const isFeatured = index === 0 && projects.length > 1;
+          return (
+            <StaggerItem
+              key={project.cardTitle}
+              className={isFeatured ? "md:col-span-2" : ""}
+            >
+              <AppCard
+                card={project}
+                variant={isFeatured ? "featured" : "default"}
+              />
+            </StaggerItem>
+          );
+        })}
+      </Stagger>
     </AppSectionWrapper>
   );
 }

--- a/src/sections/Welcome.tsx
+++ b/src/sections/Welcome.tsx
@@ -1,22 +1,94 @@
+import { Stagger, StaggerItem } from "@/components/motion/Stagger";
+import Spotlight from "@/components/motion/Spotlight";
 import AppSectionWrapper from "@/components/AppSectionWrapper";
+import { Button } from "@/components/ui/button";
 import { RootState } from "@/store/store";
+import { ArrowRight } from "lucide-react";
 import { useSelector } from "react-redux";
 
+function splitName(name: string) {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length < 2) return { first: name, rest: "" };
+  return {
+    first: parts[0],
+    rest: parts.slice(1).join(" "),
+  };
+}
+
 export default function Welcome() {
-  const welcomeData = useSelector((state: RootState) => {
-    return state.contentV2.data.home;
-  });
+  const home = useSelector((state: RootState) => state.contentV2.data.home);
+  const { first, rest } = splitName(home.name);
 
   return (
-    <AppSectionWrapper sectionId="home" nextSectionId="about">
-      <div className="flex flex-col justify-center">
-        <h1 className="text-2xl leading-relaxed md:text-[56px] font-semibold text-center text-neutral-1">
-          {welcomeData.name}
-        </h1>
-        <h2 className="text-2xl leading-relaxed md:text-[56px] font-light text-center text-neutral-2">
-          {welcomeData.description}
-        </h2>
+    <AppSectionWrapper sectionId="home" nextSectionId="about" hideHeader>
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute inset-0 bg-grid bg-grid-fade opacity-40" />
+        <Spotlight />
       </div>
+
+      <Stagger
+        staggerDelay={0.1}
+        initialDelay={0.05}
+        className="flex flex-col items-center text-center max-w-4xl mx-auto"
+      >
+        <StaggerItem>
+          <p className="text-sm md:text-base uppercase tracking-[0.2em] text-muted-foreground">
+            {home.role}
+          </p>
+        </StaggerItem>
+
+        <StaggerItem className="mt-3">
+          <h1 className="font-display text-5xl sm:text-6xl md:text-7xl lg:text-[88px] leading-[1] tracking-tight text-foreground">
+            {first}{" "}
+            <span className="text-gradient">{rest}</span>
+          </h1>
+        </StaggerItem>
+
+        <StaggerItem className="mt-6">
+          <p className="text-base md:text-xl font-light text-muted-foreground max-w-2xl">
+            {home.description}
+          </p>
+        </StaggerItem>
+
+        <StaggerItem className="mt-10">
+          <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-4 text-sm md:text-base">
+            {home.stats?.map((stat, idx) => (
+              <div key={stat.label} className="flex items-center gap-3">
+                {idx > 0 && (
+                  <span className="hidden sm:block w-px h-6 bg-border" />
+                )}
+                <div className="flex flex-col items-center sm:items-start">
+                  <span className="font-display text-xl md:text-2xl text-foreground leading-none">
+                    {stat.value}
+                  </span>
+                  <span className="text-xs uppercase tracking-wider text-muted-foreground mt-1">
+                    {stat.label}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </StaggerItem>
+
+        <StaggerItem className="mt-10">
+          <div className="flex flex-wrap justify-center gap-3">
+            <Button asChild size="lg" className="rounded-full group">
+              <a href="#contact">
+                {home.cta?.primary}
+                <ArrowRight className="transition-transform group-hover:translate-x-0.5" />
+              </a>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="rounded-full"
+            >
+              <a href="#projects">{home.cta?.secondary}</a>
+            </Button>
+          </div>
+        </StaggerItem>
+      </Stagger>
     </AppSectionWrapper>
   );
 }

--- a/src/store/slices/contentSlice-v2.ts
+++ b/src/store/slices/contentSlice-v2.ts
@@ -28,7 +28,19 @@ const contentSliceV2 = createSlice({
       })
       .addCase(fetchDataV2.fulfilled, (state, action) => {
         state.loading = false;
-        state.data = action.payload;
+        const payload = action.payload;
+        state.data = {
+          ...ENGLISH,
+          ...payload,
+          navbar: { ...ENGLISH.navbar, ...payload?.navbar },
+          home: { ...ENGLISH.home, ...payload?.home },
+          about: { ...ENGLISH.about, ...payload?.about },
+          experience: { ...ENGLISH.experience, ...payload?.experience },
+          projects: { ...ENGLISH.projects, ...payload?.projects },
+          contact: { ...ENGLISH.contact, ...payload?.contact },
+          links: { ...ENGLISH.links, ...payload?.links },
+          footer: { ...ENGLISH.footer, ...payload?.footer },
+        };
       })
       .addCase(fetchDataV2.rejected, (state, action) => {
         state.loading = false;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
   theme: {
     fontFamily: {
       sans: ["Work Sans", "sans-serif"],
+      display: ["Space Grotesk", "Work Sans", "sans-serif"],
     },
     extend: {
       keyframes: {
@@ -24,9 +25,22 @@ export default {
             borderColor: "white",
           },
         },
+        "bounce-soft": {
+          "0%, 100%": { transform: "translateY(0)" },
+          "50%": { transform: "translateY(6px)" },
+        },
       },
       animation: {
         typing: "typing 2s steps(20) forwards, blink 1s steps(1) infinite",
+        "bounce-soft": "bounce-soft 2s ease-in-out infinite",
+      },
+      transitionTimingFunction: {
+        snappy: "cubic-bezier(0.22, 1, 0.36, 1)",
+      },
+      transitionDuration: {
+        350: "350ms",
+        450: "450ms",
+        600: "600ms",
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -80,9 +94,15 @@ export default {
           2: "var(--neutral-2)",
         },
         primaryColor: "var(--primary-1)",
+        "accent-from": "hsl(var(--accent-from))",
+        "accent-to": "hsl(var(--accent-to))",
+        surface: {
+          1: "hsl(var(--surface-1))",
+          2: "hsl(var(--surface-2))",
+        },
       },
     },
   },
-  darkMode: true,
+  darkMode: "class",
   plugins: [require("tailwindcss-animate")],
 };

--- a/test/components/AppSectionWrapper.test.tsx
+++ b/test/components/AppSectionWrapper.test.tsx
@@ -17,7 +17,7 @@ describe("AppSectionWrapper", () => {
       </AppSectionWrapper>
     );
 
-    expect(screen.getByText("1.")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.getByText("Test Title")).toBeInTheDocument();
     expect(screen.getByText("Test Content")).toBeInTheDocument();
   });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,38 @@
 import "@testing-library/jest-dom";
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  observe = (target: Element) => {
+    this.callback(
+      [
+        {
+          isIntersecting: true,
+          intersectionRatio: 1,
+          target,
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRect: {} as DOMRectReadOnly,
+          rootBounds: null,
+          time: 0,
+        },
+      ],
+      this as unknown as IntersectionObserver
+    );
+  };
+  unobserve = () => {};
+  disconnect = () => {};
+  takeRecords = () => [];
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+
+if (typeof window !== "undefined" && !("IntersectionObserver" in window)) {
+  (window as unknown as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  (
+    globalThis as unknown as { IntersectionObserver: typeof IntersectionObserver }
+  ).IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+}


### PR DESCRIPTION
## Summary

Modernizes the portfolio with a refreshed visual language across all sections, a motion system powered by Framer Motion, and an extended content schema. Keeps the existing five sections but redesigns each to feel more polished and intentional.

## What changed

**Foundation**
- Added Framer Motion (~50KB gzip) for scroll-driven and gesture animations
- Display font (Space Grotesk) paired with Work Sans for hierarchy
- New design tokens: accent gradient (`--accent-from/to`), surface tiers, motion easings
- Theme-aware scrollbar colors (replaces hardcoded slate)
- Reusable motion primitives: `FadeIn`, `Stagger`, `Spotlight`
- `useActiveSection` hook (IntersectionObserver) for scroll-tracked navigation

**Content schema**
- `home` extended with `role`, `status`, `stats[]`, and `cta` (EN + PT)
- v2 slice now deep-merges Contentful payload over local defaults so missing CMS fields fall back gracefully

**Sections**
- **Welcome** — bigger display heading with gradient surname, role tag, stats row, two CTAs, spotlight background
- **About** — circular framed photo with accent ring + glow, varied bullet icons (Briefcase, Code2, Globe2, Database, Award, Zap)
- **Experience** — vertical timeline with gradient dots and connector line; **bug fix**: now renders all entries (was hardcoded to `experience[0]`)
- **Projects** — bento grid; first card uses new `featured` variant (full-width, larger heading, optional image)
- **Contact** — split layout with primary email CTA pill on the left and social cards on the right

**Components**
- `AppCard` — `default` / `featured` variants, optional `image` prop, gradient hover border, motion lift, numbered highlights, `ArrowUpRight` indicator
- `AppBullet` — accepts custom Lucide icon
- `AppNavigationMenu` — floating pill nav with animated active section indicator (Framer `layoutId`)
- `AppSectionWrapper` — bigger gradient section number with decorative divider

## Test plan

- [x] `npm run build` passes (188.89 KB gzip JS)
- [x] `npm test` — same baseline as `main` (no new regressions; 6 pre-existing failures untouched)
- [x] Manual: dark/light toggle works across all sections
- [x] Manual: language toggle (EN ↔ PT) — confirm hero `role`, `status`, `stats`, `cta` are translated
- [x] Manual: floating nav active pill animates between sections on scroll
- [x] Manual: 375px / 768px / 1280px breakpoints render correctly
- [x] Manual: Experience now lists every entry from Contentful (verify >1 entry shows)